### PR TITLE
Add Dockerfile for building RSEM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    g++ \
+    make \
+    perl \
+    python3 \
+    r-base \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /opt/rsem
+
+# Copy source
+COPY . /opt/rsem
+
+# Build and install RSEM
+RUN make && make install
+
+ENV PATH="/usr/local/bin:${PATH}"
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary
- provide a Dockerfile to build and install RSEM on Ubuntu 22.04
- install build dependencies and compile RSEM during image build

## Testing
- `make -j2`
- `docker build -t rsem-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ae0d278c8331a613eec175b9a6e1